### PR TITLE
Fix `init` subcommand help message typo

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -170,7 +170,7 @@ appP = do
 initPresetP :: Parser [InitPreset]
 initPresetP =
   (\a b c d e f' g -> catMaybes [a, b, c, d, e, f', g])
-    <$> f Amd64Linux ("linux-x86_64", "linux-arm64")
+    <$> f Amd64Linux ("linux-x86_64", "linux-amd64")
     <*> f Arm64Linux ("linux-aarch64", "linux-arm64")
     <*> f AppleSiliconMac ("macos-aarch64", "apple-silicon-mac")
     <*> f IntelMac ("macos-amd64", "intel-mac")


### PR DESCRIPTION
Hello, @dahlia. I'm trying to use dojang to setup my `dotfiles` repository.

I run `dojang init --help` to see what options are available. Then I felt `--linux-arm64` option seems not natural with `AMD64` platform.

```
  --linux-arm64,--linux-x86_64
                           Use Linux (AMD64) preset
```

When I looked related source code, it seems typo because there was already another `linux-arm64` option for `ARM64` platform.

```haskell
    <$> f Amd64Linux ("linux-x86_64", "linux-arm64")
    <*> f Arm64Linux ("linux-aarch64", "linux-arm64")
```

If it's not a typo, I apologize and please close this PR 😥 