### PR TITLE
Unify file delta semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 0.3.0
 
 To be released.
 
+ -  Unified file-state observation and delta calculation for single-file and
+    directory routes.  Dojang now detects symbolic links without following
+    them, reports removal of every tracked entry kind consistently, and
+    compares equal-size regular files by content.  [[#30], [#60]]
+
+[#30]: https://github.com/dahlia/dojang/issues/30
+[#60]: https://github.com/dahlia/dojang/pull/60
+
 
 Version 0.2.1
 -------------

--- a/src/Dojang/Types/Context.hs
+++ b/src/Dojang/Types/Context.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoFieldSelectors #-}
@@ -39,7 +38,6 @@ import GHC.IO.Exception (IOErrorType (InappropriateType))
 import GHC.Stack (HasCallStack)
 import System.IO.Error
   ( ioeSetErrorString
-  , ioeSetFileName
   , isPermissionError
   , mkIOError
   )
@@ -136,6 +134,72 @@ data FileEntry = FileEntry
 -- | The kind of change that was made to a file.
 data FileDeltaKind = Unchanged | Added | Removed | Modified
   deriving (Eq, Ord, Show)
+
+
+-- | Observes the state of a filesystem entry without following symbolic links.
+observeFileStat
+  :: (HasCallStack, MonadFileSystem m)
+  => OsPath
+  -> m FileStat
+observeFileStat path = do
+  isSymlink' <- isSymlink path
+  if isSymlink'
+    then observeKnownFileStat Dojang.MonadFileSystem.Symlink path
+    else do
+      isDirectory' <- isDirectory path
+      if isDirectory'
+        then observeKnownFileStat Dojang.MonadFileSystem.Directory path
+        else do
+          isFile' <- isFile path
+          if isFile'
+            then observeKnownFileStat Dojang.MonadFileSystem.File path
+            else return Missing
+
+
+-- | Converts a known filesystem entry type to its observed state.
+observeKnownFileStat
+  :: (HasCallStack, MonadFileSystem m)
+  => Dojang.MonadFileSystem.FileType
+  -> OsPath
+  -> m FileStat
+observeKnownFileStat Dojang.MonadFileSystem.Directory _ = return Directory
+observeKnownFileStat Dojang.MonadFileSystem.File path = File <$> getFileSize path
+observeKnownFileStat Dojang.MonadFileSystem.Symlink path =
+  Symlink <$> readSymlinkTarget path
+
+
+-- | Calculates how a current filesystem entry differs from its intermediate
+-- state.
+calculateFileDelta
+  :: (HasCallStack, MonadFileSystem m)
+  => FileEntry
+  -> FileEntry
+  -> m FileDeltaKind
+calculateFileDelta (FileEntry _ Missing) (FileEntry _ Missing) =
+  return Unchanged
+calculateFileDelta (FileEntry _ Missing) (FileEntry _ _) = return Added
+calculateFileDelta (FileEntry _ _) (FileEntry _ Missing) = return Removed
+calculateFileDelta (FileEntry _ Directory) (FileEntry _ Directory) =
+  return Unchanged
+calculateFileDelta
+  (FileEntry _ (Symlink intermediateTarget))
+  (FileEntry _ (Symlink currentTarget)) =
+    return $
+      if intermediateTarget == currentTarget
+        then Unchanged
+        else Modified
+calculateFileDelta
+  intermediateEntry@(FileEntry _ (File intermediateSize))
+  currentEntry@(FileEntry _ (File currentSize))
+    | intermediateSize /= currentSize = return Modified
+    | otherwise = do
+        intermediateContents <- readFile intermediateEntry.path
+        currentContents <- readFile currentEntry.path
+        return $
+          if intermediateContents == currentContents
+            then Unchanged
+            else Modified
+calculateFileDelta _ _ = return Modified
 
 
 -- | A correspondence between a source file, an intermediate file, and
@@ -273,14 +337,14 @@ makeCorrespondBetweenThreeFiles
   -> OsPath
   -> m FileCorrespondence
 makeCorrespondBetweenThreeFiles intermediatePath srcPath dstPath = do
-  interStat <- getFileStat intermediatePath
+  interStat <- observeFileStat intermediatePath
   let interEntry = FileEntry intermediatePath interStat
-  srcStat <- getFileStat srcPath
+  srcStat <- observeFileStat srcPath
   let srcEntry = FileEntry srcPath srcStat
-  srcDelta <- getDelta interEntry srcEntry
-  dstStat <- getFileStat dstPath
+  srcDelta <- calculateFileDelta interEntry srcEntry
+  dstStat <- observeFileStat dstPath
   let dstEntry = FileEntry dstPath dstStat
-  dstDelta <- getDelta interEntry dstEntry
+  dstDelta <- calculateFileDelta interEntry dstEntry
   return
     FileCorrespondence
       { source = srcEntry
@@ -289,40 +353,6 @@ makeCorrespondBetweenThreeFiles intermediatePath srcPath dstPath = do
       , destination = dstEntry
       , destinationDelta = dstDelta
       }
- where
-  getFileStat :: OsPath -> m FileStat
-  getFileStat path = do
-    isDir <- isDirectory path
-    when isDir $ do
-      path' <- decodePath path
-      throwError $
-        userError
-          ( "makeCorrespondBetweenThreeFiles: "
-              ++ "expected a file, but got a directory"
-          )
-          `ioeSetFileName` path'
-    exists' <- exists path
-    if exists'
-      then do
-        size <- getFileSize path
-        return $ File size
-      else return Missing
-  getDelta :: FileEntry -> FileEntry -> m FileDeltaKind
-  getDelta (FileEntry _ Missing) (FileEntry _ Missing) = return Unchanged
-  getDelta (FileEntry _ Missing) (FileEntry _ _) = return Added
-  getDelta (FileEntry _ File{}) (FileEntry _ Missing) = return Removed
-  getDelta (FileEntry _ Symlink{}) (FileEntry _ Missing) = return Removed
-  getDelta (FileEntry _ (Symlink path)) (FileEntry _ (Symlink path')) =
-    if path == path'
-      then return Unchanged
-      else return Modified
-  getDelta interEntry targetEntry =
-    if interEntry.stat /= targetEntry.stat
-      then return Modified
-      else do
-        interData <- readFile interEntry.path
-        targetData <- readFile targetEntry.path
-        return $ if interData == targetData then Unchanged else Modified
 
 
 makeCorrespondBetweenThreeDirs
@@ -343,20 +373,20 @@ makeCorrespondBetweenThreeDirs intermediatePath srcPath dstPath ignores = do
     (interEntry, srcEntry, srcDelta) <- case srcEntries !? path of
       Nothing -> return (missing, missing, Unchanged)
       Just (interEntry', srcEntry') -> do
-        delta <-
-          getDelta path srcPath interEntry'.stat srcEntry'.stat
+        delta <- getDelta path srcPath interEntry' srcEntry'
         return (interEntry', srcEntry', delta)
     (interEntry2, dstEntry, dstDelta) <- case dstEntries !? path of
       Nothing -> return (missing, missing, Unchanged)
       Just (interEntry', dstEntry') -> do
-        delta <- getDelta path dstPath interEntry'.stat dstEntry'.stat
+        delta <- getDelta path dstPath interEntry' dstEntry'
         return (interEntry', dstEntry', delta)
     (dstEntry', dstDelta') <-
       if null ignores || dstEntry.stat /= Missing
         then return (dstEntry, dstDelta)
         else do
-          actualDstStat <- getFileStat (dstPath </> path)
-          actualDelta <- getDelta path dstPath interEntry2.stat actualDstStat
+          actualDstStat <- observeFileStat (dstPath </> path)
+          let actualDstEntry = FileEntry path actualDstStat
+          actualDelta <- getDelta path dstPath interEntry2 actualDstEntry
           return (dstEntry{stat = actualDstStat}, actualDelta)
     return $
       FileCorrespondence
@@ -375,49 +405,15 @@ makeCorrespondBetweenThreeDirs intermediatePath srcPath dstPath ignores = do
     -- \^ The relative path to the file.
     -> OsPath
     -- \^ The path to the target directory.
-    -> FileStat
-    -- \^ An intermediate file stat.
-    -> FileStat
-    -- \^ A target (source or destination) file stat.
+    -> FileEntry
+    -- \^ An intermediate file entry.
+    -> FileEntry
+    -- \^ A target (source or destination) file entry.
     -> m FileDeltaKind
-  getDelta _ _ Directory Directory = return Unchanged
-  getDelta _ _ Directory Missing = return Removed
-  getDelta _ _ Directory _ = return Modified
-  getDelta path targetPath (File size) (File size') =
-    if size /= size'
-      then return Modified
-      else do
-        interData <- readFile (intermediatePath </> path)
-        targetData <- readFile (targetPath </> path)
-        return $ if interData == targetData then Unchanged else Modified
-  getDelta _ _ (File _) Missing = return Removed
-  getDelta _ _ (File _) _ = return Modified
-  getDelta _ _ (Symlink path) (Symlink path') =
-    if path == path'
-      then return Unchanged
-      else return Modified
-  getDelta _ _ (Symlink _) Missing = return Added
-  getDelta _ _ (Symlink _) _ = return Modified
-  getDelta _ _ Missing Missing = return Unchanged
-  getDelta _ _ Missing _ = return Added
-  getFileStat :: OsPath -> m FileStat
-  getFileStat path' = do
-    isSym <- isSymlink path'
-    if isSym
-      then do
-        target <- readSymlinkTarget path'
-        return $ Symlink target
-      else do
-        isDir <- isDirectory path'
-        if isDir
-          then return Directory
-          else do
-            isFle <- isFile path'
-            if isFle
-              then do
-                size <- getFileSize path'
-                return $ File size
-              else return Missing
+  getDelta path targetPath intermediateEntry targetEntry =
+    calculateFileDelta
+      intermediateEntry{path = intermediatePath </> path}
+      targetEntry{path = targetPath </> path}
 
 
 makeCorrespondBetweenTwoDirs
@@ -490,15 +486,9 @@ listFiles path ignorePatterns = do
           if isPermissionError e
             then return []
             else throwError e
-      forM entries $ \case
-        (Dojang.MonadFileSystem.Directory, d) ->
-          return $ FileEntry d Directory
-        (Dojang.MonadFileSystem.File, f) -> do
-          size <- getFileSize $ path </> f
-          return $ FileEntry f $ File size
-        (Dojang.MonadFileSystem.Symlink, s) -> do
-          target <- readSymlinkTarget $ path </> s
-          return $ FileEntry s $ Symlink target
+      forM entries $ \(fileType, entryPath) -> do
+        stat <- observeKnownFileStat fileType $ path </> entryPath
+        return $ FileEntry entryPath stat
     else return []
 
 
@@ -697,7 +687,7 @@ getIgnoredFiles ctx = do
           then return []
           else do
             -- List all files (including those that would be ignored)
-            allFiles <- listFilesWithoutIgnore route.destinationPath
+            allFiles <- listFiles route.destinationPath []
             -- Find which files match ignore patterns
             forM allFiles $ \entry -> do
               relPath <- decodePath entry.path
@@ -717,27 +707,6 @@ getIgnoredFiles ctx = do
  where
   ignorePatterns :: Map OsPath [FilePattern]
   ignorePatterns = ctx.repository.manifest.ignorePatterns
-
-  listFilesWithoutIgnore :: OsPath -> m [FileEntry]
-  listFilesWithoutIgnore path = do
-    exists' <- exists path
-    if exists'
-      then do
-        entries <-
-          listDirectoryRecursively path [] `catchError` \e ->
-            if isPermissionError e
-              then return []
-              else throwError e
-        forM entries $ \case
-          (Dojang.MonadFileSystem.Directory, d) ->
-            return $ FileEntry d Directory
-          (Dojang.MonadFileSystem.File, f) -> do
-            size <- getFileSize $ path </> f
-            return $ FileEntry f $ File size
-          (Dojang.MonadFileSystem.Symlink, s) -> do
-            target <- readSymlinkTarget $ path </> s
-            return $ FileEntry s $ Symlink target
-      else return []
 
 
 -- | Represents a file that is not registered in any route.
@@ -774,7 +743,7 @@ getUnregisteredFiles ctx = do
   unregisteredLists <- forM routes $ \route ->
     case route.fileType of
       Dojang.MonadFileSystem.Directory -> do
-        allFiles <- listFilesInDir route.destinationPath
+        allFiles <- listFiles route.destinationPath []
         let unregistered =
               [ f
               | f <- allFiles
@@ -791,29 +760,7 @@ getUnregisteredFiles ctx = do
               , candidateRoutes = candidates
               }
       _ -> return []
-
   return $ concat unregisteredLists
- where
-  listFilesInDir :: OsPath -> m [FileEntry]
-  listFilesInDir path = do
-    exists' <- exists path
-    if exists'
-      then do
-        entries <-
-          listDirectoryRecursively path [] `catchError` \e ->
-            if isPermissionError e
-              then return []
-              else throwError e
-        forM entries $ \case
-          (Dojang.MonadFileSystem.Directory, d) ->
-            return $ FileEntry d Directory
-          (Dojang.MonadFileSystem.File, f) -> do
-            size <- getFileSize $ path </> f
-            return $ FileEntry f $ File size
-          (Dojang.MonadFileSystem.Symlink, s) -> do
-            target <- readSymlinkTarget $ path </> s
-            return $ FileEntry s $ Symlink target
-      else return []
 
 
 -- | Finds candidate routes for an unregistered file.

--- a/test/Dojang/Types/ContextSpec.hs
+++ b/test/Dojang/Types/ContextSpec.hs
@@ -6,22 +6,29 @@
 
 module Dojang.Types.ContextSpec (spec) where
 
-import Data.List (isInfixOf, sort, sortOn)
+import Control.Monad (forM_)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.List (find, isInfixOf, sort, sortOn)
 import System.IO.Error
-  ( ioeGetErrorString
-  , ioeGetErrorType
+  ( ioeGetErrorType
   , ioeGetFileName
   , ioeGetLocation
   )
 import Prelude hiding (readFile, writeFile)
 
+import Control.Monad.Except (MonadError (catchError))
 import Data.ByteString qualified (length)
+import Data.ByteString qualified as ByteString
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map, fromList)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range (linear)
+import System.Directory.OsPath (createDirectoryLink, createFileLink)
 import System.FilePath (combine)
 import System.OsPath (OsPath, encodeFS, (</>))
-import Test.Hspec (Spec, describe, it, runIO, specify)
+import Test.Hspec (Spec, describe, it, runIO, specify, xit)
 import Test.Hspec.Expectations.Pretty (shouldBe, shouldReturn, shouldThrow)
+import Test.Hspec.Hedgehog (MonadGen, forAll, hedgehog, (===))
 
 import Dojang.MonadFileSystem (MonadFileSystem (..))
 import Dojang.MonadFileSystem qualified (FileType (..))
@@ -67,6 +74,119 @@ import Dojang.Types.Repository
 import GHC.IO.Exception (IOErrorType (InappropriateType))
 
 
+data TestFileState
+  = TestMissing
+  | TestDirectory
+  | TestFile ByteString.ByteString
+  | TestSymlink TestLinkTarget
+  deriving (Eq, Show)
+
+
+data TestLinkTarget = TestFileTarget | TestDirectoryTarget
+  deriving (Eq, Show)
+
+
+expectedDelta :: TestFileState -> TestFileState -> FileDeltaKind
+expectedDelta TestMissing TestMissing = Unchanged
+expectedDelta TestMissing _ = Added
+expectedDelta _ TestMissing = Removed
+expectedDelta TestDirectory TestDirectory = Unchanged
+expectedDelta (TestFile a) (TestFile b)
+  | a == b = Unchanged
+  | otherwise = Modified
+expectedDelta (TestSymlink a) (TestSymlink b)
+  | a == b = Unchanged
+  | otherwise = Modified
+expectedDelta _ _ = Modified
+
+
+testFileState :: (MonadGen m) => Bool -> m TestFileState
+testFileState symlinkAvailable =
+  Gen.choice $
+    [ return TestMissing
+    , return TestDirectory
+    , TestFile <$> Gen.bytes (linear 0 64)
+    ]
+      ++ [ TestSymlink
+             <$> Gen.element
+               ([TestFileTarget, TestDirectoryTarget] :: [TestLinkTarget])
+         | symlinkAvailable
+         ]
+
+
+observeTransitionBothWays
+  :: TestFileState
+  -> TestFileState
+  -> IO (FileDeltaKind, FileDeltaKind)
+observeTransitionBothWays intermediateState currentState =
+  withTempDir $ \tmpDir _ -> do
+    inter <- encodePath "inter"
+    src <- encodePath "src"
+    dst <- encodePath "dst"
+    interDir <- encodePath "inter-dir"
+    srcDir <- encodePath "src-dir"
+    dstDir <- encodePath "dst-dir"
+    entry <- encodePath "entry"
+    fileTarget <- encodePath "file-target"
+    directoryTarget <- encodePath "directory-target"
+    let fileTargetPath = tmpDir </> fileTarget
+    let directoryTargetPath = tmpDir </> directoryTarget
+    writeFile fileTargetPath "target"
+    createDirectory directoryTargetPath
+    createDirectory $ tmpDir </> interDir
+    createDirectory $ tmpDir </> srcDir
+    createDirectory $ tmpDir </> dstDir
+    materializeState
+      fileTargetPath
+      directoryTargetPath
+      (tmpDir </> inter)
+      intermediateState
+    materializeState
+      fileTargetPath
+      directoryTargetPath
+      (tmpDir </> src)
+      currentState
+    materializeState
+      fileTargetPath
+      directoryTargetPath
+      (tmpDir </> interDir </> entry)
+      intermediateState
+    materializeState
+      fileTargetPath
+      directoryTargetPath
+      (tmpDir </> srcDir </> entry)
+      currentState
+    single <-
+      makeCorrespondBetweenThreeFiles
+        (tmpDir </> inter)
+        (tmpDir </> src)
+        (tmpDir </> dst)
+    directory <-
+      makeCorrespondBetweenThreeDirs
+        (tmpDir </> interDir)
+        (tmpDir </> srcDir)
+        (tmpDir </> dstDir)
+        []
+    let directoryDelta =
+          maybe Unchanged (.sourceDelta) $
+            find ((== entry) . (.source.path)) directory
+    return (single.sourceDelta, directoryDelta)
+ where
+  materializeState
+    :: OsPath
+    -> OsPath
+    -> OsPath
+    -> TestFileState
+    -> IO ()
+  materializeState _ _ _ TestMissing = return ()
+  materializeState _ _ path TestDirectory = createDirectory path
+  materializeState _ _ path (TestFile contents) = writeFile path contents
+  materializeState fileTarget _ path (TestSymlink TestFileTarget) =
+    createFileLink fileTarget path
+  materializeState _ directoryTarget path (TestSymlink TestDirectoryTarget) =
+    createDirectoryLink directoryTarget path
+
+
 spec :: Spec
 spec = do
   src <- runIO $ encodeFS "src"
@@ -81,6 +201,15 @@ spec = do
   corge <- runIO $ encodeFS "corge"
   intermediateDir <- runIO $ encodeFS ".dojang"
   manifestFilename' <- runIO $ encodeFS "dojang.toml"
+
+  symlinkAvailable <- runIO $ withTempDir $ \tmpDir _ ->
+    ( do
+        writeFile (tmpDir </> foo) ""
+        createFileLink (tmpDir </> foo) (tmpDir </> bar)
+        return True
+    )
+      `catchError` const (return False)
+  let symIt = if symlinkAvailable then it else xit
 
   let Right posix = parseMonikerName "posix"
   let Right undefined' = parseMonikerName "undefined"
@@ -390,15 +519,104 @@ spec = do
         , destinationDelta = Removed
         }
 
-    writeFile (tmpDir </> inter) "dir is disallowed"
+    writeFile (tmpDir </> inter) "file to directory"
     createDirectory (tmpDir </> src)
-    filename <- decodePath $ tmpDir </> src
-    makeCorrespond_ `shouldThrow` \e ->
-      ( ioeGetErrorString e
-          == "makeCorrespondBetweenThreeFiles: "
-            ++ "expected a file, but got a directory"
-      )
-        && (ioeGetFileName e == Just filename)
+    makeCorrespond_
+      `shouldReturn` FileCorrespondence
+        { source = FileEntry (tmpDir </> src) Directory
+        , sourceDelta = Modified
+        , intermediate = FileEntry (tmpDir </> inter) $ File 17
+        , destination = FileEntry (tmpDir </> dst) Missing
+        , destinationDelta = Removed
+        }
+
+  describe "file delta semantics" $ do
+    let representativeStates =
+          [TestMissing, TestDirectory, TestFile "contents"]
+            ++ if symlinkAvailable
+              then
+                [ TestSymlink TestFileTarget
+                , TestSymlink TestDirectoryTarget
+                ]
+              else []
+    forM_ representativeStates $ \intermediateState ->
+      forM_ representativeStates $ \currentState ->
+        it
+          ( "classifies "
+              ++ show intermediateState
+              ++ " to "
+              ++ show currentState
+          )
+          $ do
+            (singleDelta, directoryDelta) <-
+              observeTransitionBothWays intermediateState currentState
+            let expected = expectedDelta intermediateState currentState
+            singleDelta `shouldBe` expected
+            directoryDelta `shouldBe` expected
+
+    it "keeps single-file and directory deltas equivalent" $ hedgehog $ do
+      intermediateState <- forAll $ testFileState symlinkAvailable
+      currentState <- forAll $ testFileState symlinkAvailable
+      (singleDelta, directoryDelta) <-
+        liftIO $ observeTransitionBothWays intermediateState currentState
+      let expected = expectedDelta intermediateState currentState
+      singleDelta === expected
+      directoryDelta === expected
+
+    it "compares arbitrary equal file contents" $ hedgehog $ do
+      contents <- forAll $ Gen.bytes (linear 0 64)
+      (singleDelta, directoryDelta) <-
+        liftIO $
+          observeTransitionBothWays
+            (TestFile contents)
+            (TestFile contents)
+      singleDelta === Unchanged
+      directoryDelta === Unchanged
+
+    it "compares arbitrary unequal same-size file contents" $ hedgehog $ do
+      prefix <- forAll $ Gen.bytes (linear 0 63)
+      let intermediateContents = prefix <> ByteString.singleton 0
+      let currentContents = prefix <> ByteString.singleton 1
+      (singleDelta, directoryDelta) <-
+        liftIO $
+          observeTransitionBothWays
+            (TestFile intermediateContents)
+            (TestFile currentContents)
+      singleDelta === Modified
+      directoryDelta === Modified
+
+    symIt "observes symlinks without following their targets" $
+      withTempDir $ \tmpDir _ -> do
+        fileTarget <- encodePath "file-target"
+        directoryTarget <- encodePath "directory-target"
+        interLink <- encodePath "inter-link"
+        srcLink <- encodePath "src-link"
+        dstLink <- encodePath "dst-link"
+        writeFile (tmpDir </> fileTarget) "target"
+        createDirectory $ tmpDir </> directoryTarget
+        createFileLink (tmpDir </> fileTarget) (tmpDir </> interLink)
+        createFileLink (tmpDir </> fileTarget) (tmpDir </> srcLink)
+        createDirectoryLink
+          (tmpDir </> directoryTarget)
+          (tmpDir </> dstLink)
+        correspond <-
+          makeCorrespondBetweenThreeFiles
+            (tmpDir </> interLink)
+            (tmpDir </> srcLink)
+            (tmpDir </> dstLink)
+        correspond
+          `shouldBe` FileCorrespondence
+            { source =
+                FileEntry (tmpDir </> srcLink) $ Symlink (tmpDir </> fileTarget)
+            , sourceDelta = Unchanged
+            , intermediate =
+                FileEntry (tmpDir </> interLink) $ Symlink (tmpDir </> fileTarget)
+            , destination =
+                FileEntry
+                  (tmpDir </> dstLink)
+                  (Symlink $ tmpDir </> directoryTarget)
+            , destinationDelta = Modified
+            }
 
   specify "makeCorrespondBetweenThreeDirs" $ withTempDir $ \tmpDir _ -> do
     () <-


### PR DESCRIPTION
Dojang's reconciliation work needs one stable answer to a basic question: how does a filesystem entry differ from the intermediate snapshot?  Until now, *src/Dojang/Types/Context.hs* answered it separately for single-file routes and entries found inside directory routes.  The two paths did not observe symbolic links in the same way, and they disagreed on some transitions.  Any planner built on those results would inherit that ambiguity.

Closes #30.

## Separate observation from comparison

The comparison now starts from an explicit observation step.  It checks for a symbolic link before asking questions that would follow the link, then records the entry as missing, a directory, a regular file with its size, or a symbolic link with its target.  Directory walks feed their already known entry types through the same conversion, so direct routes and recursive routes share the same vocabulary without repeating filesystem probes.

A single effectful comparison function applies the transition rules.  Missing entries determine additions and removals, different entry kinds are modified, directories compare by kind, and symbolic links compare by target.  Regular files use their sizes as a cheap first check and read bytes only when the sizes match.  Directory correspondences resolve their relative entries to full paths only for that byte comparison, leaving the paths returned to callers unchanged.

This separation keeps observation policy out of the transition table.  It also gives the reconciliation planner tracked in https://github.com/dahlia/dojang/issues/28 one consistent delta vocabulary to consume.

## Test the invariant, not each implementation

The regression tests in *test/Dojang/Types/ContextSpec.hs* describe the complete state transition matrix.  A shared fixture materializes the same intermediate and current states through both correspondence APIs, including links to files and directories.  Hedgehog then generates state pairs and arbitrary file contents to check that both APIs agree with the model, that equal bytes remain unchanged, and that different bytes of the same size are still modified.

The full test suite and repository checks pass:

~~~~ bash
mise run test:fast
mise run check
~~~~
