### PR TITLE
Make reconciliation inspectable before execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,20 @@ Version 0.3.0
 
 To be released.
 
+ -  Added a pure, direction-aware reconciliation planner and a shared
+    filesystem operation executor.  Plans expose conflicts, skipped entries,
+    and destructive operations before execution, providing the foundation for
+    unifying `dojang apply` and `dojang reflect`.  [[#29], [#61]]
+
  -  Unified file-state observation and delta calculation for single-file and
     directory routes.  Dojang now detects symbolic links without following
     them, reports removal of every tracked entry kind consistently, and
     compares equal-size regular files by content.  [[#30], [#60]]
 
+[#29]: https://github.com/dahlia/dojang/issues/29
 [#30]: https://github.com/dahlia/dojang/issues/30
 [#60]: https://github.com/dahlia/dojang/pull/60
+[#61]: https://github.com/dahlia/dojang/pull/61
 
 
 Version 0.2.1

--- a/src/Dojang/Commands/Apply.hs
+++ b/src/Dojang/Commands/Apply.hs
@@ -60,6 +60,7 @@ import Dojang.Types.Context
   )
 import Dojang.Types.Environment (Environment (..))
 import Dojang.Types.Hook (HookType (..))
+import Dojang.Types.Reconciliation (SyncOp (..), executeSyncOp)
 import Dojang.Types.Registry
   ( Registry (..)
   , readRegistry
@@ -147,7 +148,7 @@ apply force filePaths = do
           & nub
             . sort
   shimOps <- liftIO $ dryRunIO $ do
-    forM_ ops doSyncOp
+    forM_ ops executeSyncOp
     let ctx' = Context ctx.repository ctx.environment lookupEnv'
     (files', _) <- makeCorrespond ctx'
     syncIntermediateToDestination
@@ -200,7 +201,7 @@ apply force filePaths = do
   -- When everything is fine (or excused):
   debug' <- asks (.debug)
   when debug' (void $ status defaultStatusOptions)
-  forM_ ops $ \path -> printSyncOp path >> doSyncOp path
+  forM_ ops $ \path -> printSyncOp path >> executeSyncOp path
   when debug' (void $ status defaultStatusOptions)
   (files', _) <- makeCorrespond ctx
   $(logDebugSH) files'
@@ -210,7 +211,7 @@ apply force filePaths = do
       [ (fc.intermediate, fc.destination, fc.destinationDelta)
       | fc <- files'
       ]
-  forM_ (nub $ sort ops') $ \path -> printSyncOp path >> doSyncOp path
+  forM_ (nub $ sort ops') $ \path -> printSyncOp path >> executeSyncOp path
   printWarnings ws
 
   -- Run post-apply hooks
@@ -279,27 +280,6 @@ filterConflicts = filterM $ \c -> case (c.sourceDelta, c.destinationDelta) of
   _ -> return True
 
 
-data SyncOp
-  = RemoveDirs OsPath
-  | RemoveFile OsPath
-  | CopyFile OsPath OsPath
-  | CreateDir OsPath
-  | CreateDirs OsPath
-  deriving (Eq, Show)
-
-
-syncOpOrdKey :: SyncOp -> (OsPath, Int, OsPath)
-syncOpOrdKey (RemoveFile path) = (takeDirectory path, 1, path)
-syncOpOrdKey (RemoveDirs path) = (path, 2, path)
-syncOpOrdKey (CreateDir path) = (path, 3, path)
-syncOpOrdKey (CreateDirs path) = (path, 4, path)
-syncOpOrdKey (CopyFile _ dst) = (takeDirectory dst, 5, dst)
-
-
-instance Ord SyncOp where
-  compare a b = compare (syncOpOrdKey a) (syncOpOrdKey b)
-
-
 printSyncOp :: (MonadIO i) => SyncOp -> App i ()
 printSyncOp (RemoveDirs path) = do
   pathStyle <- pathStyleFor stderr
@@ -320,14 +300,6 @@ printSyncOp (CreateDirs path) = do
   pathStyle <- pathStyleFor stderr
   let path' = addTrailingPathSeparator path
   printStderr ("Create " <> pathStyle path' <> " (and its ancestors)...")
-
-
-doSyncOp :: (MonadFileSystem i) => SyncOp -> i ()
-doSyncOp (RemoveDirs path) = removeDirectoryRecursively path
-doSyncOp (RemoveFile path) = removeFile path
-doSyncOp (CopyFile src dst) = copyFile src dst
-doSyncOp (CreateDir path) = createDirectory path
-doSyncOp (CreateDirs path) = createDirectories path
 
 
 syncSourceToIntermediate

--- a/src/Dojang/Commands/Apply.hs
+++ b/src/Dojang/Commands/Apply.hs
@@ -60,7 +60,11 @@ import Dojang.Types.Context
   )
 import Dojang.Types.Environment (Environment (..))
 import Dojang.Types.Hook (HookType (..))
-import Dojang.Types.Reconciliation (SyncOp (..), executeSyncOp)
+import Dojang.Types.Reconciliation
+  ( SyncOp (..)
+  , executeSyncOp
+  , isDestructiveSyncOp
+  )
 import Dojang.Types.Registry
   ( Registry (..)
   , readRegistry
@@ -156,7 +160,7 @@ apply force filePaths = do
       [ (fc.intermediate, fc.destination, fc.destinationDelta)
       | fc <- files'
       ]
-  when (any isDeletion shimOps) $ do
+  when (any isDestructiveSyncOp shimOps) $ do
     forM_ shimOps $ \case
       RemoveDirs path -> do
         let path' = addTrailingPathSeparator path
@@ -186,18 +190,20 @@ apply force filePaths = do
         <> pathStyle manifestFile'
         <> ")."
   -- Exit if there are any problems (unless forced):
-  when (not force && (not (null conflicts) || any isDeletion shimOps)) $ do
-    printStderr' Hint $
-      "Use "
-        <> codeStyle "-f"
-        <> "/"
-        <> codeStyle "--force"
-        <> " to ignore these warnings and go ahead."
-    liftIO $
-      exitWith $
-        if not (null conflicts)
-          then conflictError
-          else accidentalDeletionWarning
+  when
+    (not force && (not (null conflicts) || any isDestructiveSyncOp shimOps))
+    $ do
+      printStderr' Hint $
+        "Use "
+          <> codeStyle "-f"
+          <> "/"
+          <> codeStyle "--force"
+          <> " to ignore these warnings and go ahead."
+      liftIO $
+        exitWith $
+          if not (null conflicts)
+            then conflictError
+            else accidentalDeletionWarning
   -- When everything is fine (or excused):
   debug' <- asks (.debug)
   when debug' (void $ status defaultStatusOptions)
@@ -251,11 +257,6 @@ apply force filePaths = do
                 return True
           when proceed $ writeRegistry registryPath $ Registry currentRepo
   return ExitSuccess
- where
-  isDeletion :: SyncOp -> Bool
-  isDeletion (RemoveDirs _) = True
-  isDeletion (RemoveFile _) = True
-  isDeletion _ = False
 
 
 -- TODO: This should be in another module:

--- a/src/Dojang/Types/Context.hs
+++ b/src/Dojang/Types/Context.hs
@@ -15,6 +15,7 @@ module Dojang.Types.Context
   , RouteMatch (..)
   , RouteState (..)
   , UnregisteredFile (..)
+  , calculateFileDelta
   , calculateSpecificity
   , filterBySpecificity
   , findCandidateRoutesFor

--- a/src/Dojang/Types/Reconciliation.hs
+++ b/src/Dojang/Types/Reconciliation.hs
@@ -377,7 +377,12 @@ planSupportedInput direction input
 
   planExisting :: (ReconciliationOutcome, [TaggedOperation])
   planExisting =
-    let intermediateOperations =
+    let ignored = case (direction, input.destinationRouteState) of
+          (SourceToDestination, Ignored route pattern)
+            | targetNeedsUpdate ->
+                Just $ IgnoredDestination route pattern
+          _ -> Nothing
+        intermediateOperations =
           if authoritativeDelta == Unchanged
             then []
             else
@@ -386,13 +391,20 @@ planSupportedInput direction input
         stagedIntermediate =
           FileEntry correspondence.intermediate.path authoritative.stat
         targetOperations =
-          if not targetNeedsUpdate
-            then []
-            else
-              tagOperations SecondPhase overwrittenReplica $
-                replaceEntry stagedIntermediate overwritten
+          case ignored of
+            Just _ -> []
+            Nothing
+              | not targetNeedsUpdate -> []
+              | otherwise ->
+                  tagOperations SecondPhase overwrittenReplica $
+                    replaceEntry stagedIntermediate overwritten
         operations = intermediateOperations ++ targetOperations
-    in (if null operations then NoChange else WillReconcile, operations)
+        outcome = case ignored of
+          Just reason -> Skipped reason
+          Nothing
+            | null operations -> NoChange
+            | otherwise -> WillReconcile
+    in (outcome, operations)
 
 
 isSymlinkStat :: FileStat -> Bool

--- a/src/Dojang/Types/Reconciliation.hs
+++ b/src/Dojang/Types/Reconciliation.hs
@@ -328,6 +328,7 @@ planSupportedInput
   -> ReconciliationInput
   -> (ReconciliationOutcome, [TaggedOperation])
 planSupportedInput direction input
+  | Just reason <- ignoredAuthoritative = (Skipped reason, [])
   | isSymlinkStat authoritative.stat
       && (authoritativeDelta /= Unchanged || targetNeedsUpdate) =
       (Skipped UnsupportedSymlink, [])
@@ -351,6 +352,12 @@ planSupportedInput direction input
         )
   targetNeedsUpdate =
     input.sourceDestinationComparison == ReplicasDifferent
+  ignoredAuthoritative =
+    case (direction, input.destinationRouteState) of
+      (DestinationToSource, Ignored route pattern)
+        | authoritativeDelta /= Unchanged || targetNeedsUpdate ->
+            Just $ IgnoredDestination route pattern
+      _ -> Nothing
   planRemoval :: (ReconciliationOutcome, [TaggedOperation])
   planRemoval =
     let ignored = case (direction, input.destinationRouteState) of

--- a/src/Dojang/Types/Reconciliation.hs
+++ b/src/Dojang/Types/Reconciliation.hs
@@ -1,0 +1,548 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- | Pure reconciliation planning and filesystem-plan execution.
+module Dojang.Types.Reconciliation
+  ( ConflictPolicy (..)
+  , PlannedSyncOp (..)
+  , ReconciliationConflict (..)
+  , ReconciliationDirection (..)
+  , ReconciliationInput (..)
+  , ReconciliationItem (..)
+  , ReconciliationOutcome (..)
+  , ReconciliationPlan (..)
+  , ReconciliationSkipReason (..)
+  , Replica (..)
+  , ReplicaComparison (..)
+  , SyncOp (..)
+  , destructiveOperations
+  , executeReconciliationPlan
+  , executeSyncOp
+  , isDestructiveSyncOp
+  , observeReconciliationInput
+  , planReconciliation
+  ) where
+
+import Control.Monad (forM_)
+import Control.Monad.IO.Class (MonadIO)
+import Data.List (isPrefixOf, nub, sortBy, sortOn)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import System.FilePattern (FilePattern)
+import System.OsPath
+  ( OsPath
+  , normalise
+  , splitDirectories
+  , takeDirectory
+  )
+
+import Dojang.MonadFileSystem (MonadFileSystem (..))
+import Dojang.Types.Context
+  ( Context
+  , FileCorrespondence (..)
+  , FileDeltaKind (..)
+  , FileEntry (..)
+  , FileStat (..)
+  , RouteState (..)
+  , calculateFileDelta
+  , getRouteState
+  )
+
+
+-- | The direction in which reconciliation makes replicas converge.
+data ReconciliationDirection
+  = -- | Treat the repository source as authoritative.
+    SourceToDestination
+  | -- | Treat the machine destination as authoritative.
+    DestinationToSource
+  deriving (Eq, Ord, Show)
+
+
+-- | The policy to apply to incompatible changes on both sides.
+data ConflictPolicy
+  = -- | Report conflicts and refuse to execute the whole plan.
+    RefuseConflicts
+  | -- | Resolve conflicts in favor of the direction's authoritative side.
+    PreferAuthoritative
+  deriving (Eq, Ord, Show)
+
+
+-- | One of the three replicas participating in reconciliation.
+data Replica
+  = -- | The source file in the repository.
+    SourceReplica
+  | -- | The common-ancestor snapshot.
+    IntermediateReplica
+  | -- | The destination file on the current machine.
+    DestinationReplica
+  deriving (Eq, Ord, Show)
+
+
+-- | Whether the source and destination contain equivalent states.
+data ReplicaComparison
+  = -- | Source and destination have equivalent states and contents.
+    ReplicasEquivalent
+  | -- | Source and destination differ in state or contents.
+    ReplicasDifferent
+  deriving (Eq, Ord, Show)
+
+
+-- | A correspondence plus the observations needed by the pure planner.
+data ReconciliationInput = ReconciliationInput
+  { correspondence :: FileCorrespondence
+  -- ^ The observed source, intermediate, and destination entries.
+  , sourceDestinationComparison :: ReplicaComparison
+  -- ^ Whether source and destination are equivalent to each other.
+  , destinationRouteState :: RouteState
+  -- ^ The routing state observed for the destination path.
+  }
+  deriving (Eq, Ord, Show)
+
+
+-- | A two-sided change that cannot be reconciled without a preference.
+newtype ReconciliationConflict = ReconciliationConflict
+  { correspondence :: FileCorrespondence
+  -- ^ The conflicting correspondence.
+  }
+  deriving (Eq, Ord, Show)
+
+
+-- | Why a correspondence could not be fully reconciled.
+data ReconciliationSkipReason
+  = -- | The destination is protected by an ignore pattern.
+    IgnoredDestination OsPath FilePattern
+  | -- | Reconciliation would require creating a symbolic link, which the
+    -- current filesystem operation vocabulary cannot express.
+    UnsupportedSymlink
+  deriving (Eq, Ord, Show)
+
+
+-- | The planning result for one correspondence.
+data ReconciliationOutcome
+  = -- | Every replica already has the desired state.
+    NoChange
+  | -- | At least one operation will reconcile the correspondence.
+    WillReconcile
+  | -- | An incompatible two-sided change was refused.
+    ConflictDetected
+  | -- | Some or all work was skipped for the given reason.
+    Skipped ReconciliationSkipReason
+  deriving (Eq, Ord, Show)
+
+
+-- | The result associated with one reconciliation input.
+data ReconciliationItem = ReconciliationItem
+  { correspondence :: FileCorrespondence
+  -- ^ The correspondence being described.
+  , desiredEntry :: FileEntry
+  -- ^ The authoritative entry whose state and contents are desired for all
+  -- replicas.  Its path remains the authoritative replica's path.
+  , outcome :: ReconciliationOutcome
+  -- ^ The result chosen by the planner.
+  }
+  deriving (Eq, Ord, Show)
+
+
+-- | A filesystem synchronization operation.
+data SyncOp
+  = -- | Remove a directory and all of its children.
+    RemoveDirs OsPath
+  | -- | Remove a regular file or symbolic link.
+    RemoveFile OsPath
+  | -- | Copy a regular file from the first path to the second path.
+    CopyFile OsPath OsPath
+  | -- | Create one directory whose parent already exists.
+    CreateDir OsPath
+  | -- | Create a directory and any missing ancestors.
+    CreateDirs OsPath
+  deriving (Eq, Show)
+
+
+syncOpOrdKey :: SyncOp -> (OsPath, Int, OsPath)
+syncOpOrdKey (RemoveFile path) = (takeDirectory path, 1, path)
+syncOpOrdKey (RemoveDirs path) = (path, 2, path)
+syncOpOrdKey (CreateDir path) = (path, 3, path)
+syncOpOrdKey (CreateDirs path) = (path, 4, path)
+syncOpOrdKey (CopyFile _ destination) =
+  (takeDirectory destination, 5, destination)
+
+
+instance Ord SyncOp where
+  compare a b = compare (syncOpOrdKey a) (syncOpOrdKey b)
+
+
+-- | A synchronization operation annotated with the replica it mutates.
+data PlannedSyncOp = PlannedSyncOp
+  { replica :: Replica
+  -- ^ The replica changed by the operation.
+  , syncOp :: SyncOp
+  -- ^ The filesystem operation to execute.
+  }
+  deriving (Eq, Ord, Show)
+
+
+-- | A complete, inspectable reconciliation plan.
+data ReconciliationPlan = ReconciliationPlan
+  { direction :: ReconciliationDirection
+  -- ^ The authoritative direction used to build the plan.
+  , conflictPolicy :: ConflictPolicy
+  -- ^ The conflict policy used to build the plan.
+  , items :: [ReconciliationItem]
+  -- ^ Per-correspondence planning results in stable order.
+  , conflicts :: [ReconciliationConflict]
+  -- ^ Incompatible two-sided changes, including overridden conflicts.
+  , operations :: [PlannedSyncOp]
+  -- ^ Filesystem operations in execution order.
+  }
+  deriving (Eq, Show)
+
+
+-- | Observes the facts needed to turn a correspondence into pure planner
+-- input.  File contents are compared only when both sides changed and file
+-- metadata cannot decide equivalence.
+observeReconciliationInput
+  :: (MonadFileSystem m, MonadIO m)
+  => Context m
+  -- ^ The repository context used to observe destination routing.
+  -> FileCorrespondence
+  -- ^ The correspondence whose remaining facts should be observed.
+  -> m ReconciliationInput
+  -- ^ Pure planner input containing the correspondence and extra observations.
+observeReconciliationInput context correspondence = do
+  comparison <- observeComparison correspondence
+  (routeState, _) <- getRouteState context correspondence.destination.path
+  return
+    ReconciliationInput
+      { correspondence = correspondence
+      , sourceDestinationComparison = comparison
+      , destinationRouteState = routeState
+      }
+ where
+  observeComparison
+    :: (MonadFileSystem m) => FileCorrespondence -> m ReplicaComparison
+  observeComparison value =
+    case (value.sourceDelta, value.destinationDelta) of
+      (Unchanged, Unchanged) -> return ReplicasEquivalent
+      (Unchanged, _) -> return ReplicasDifferent
+      (_, Unchanged) -> return ReplicasDifferent
+      (Removed, Removed) -> return ReplicasEquivalent
+      _ -> do
+        delta <- calculateFileDelta value.source value.destination
+        return $
+          if delta == Unchanged
+            then ReplicasEquivalent
+            else ReplicasDifferent
+
+
+-- | Produces a pure reconciliation plan from fully observed inputs.
+planReconciliation
+  :: ReconciliationDirection
+  -- ^ The authoritative direction.
+  -> ConflictPolicy
+  -- ^ The policy for incompatible two-sided changes.
+  -> [ReconciliationInput]
+  -- ^ Fully observed correspondences to reconcile.
+  -> ReconciliationPlan
+  -- ^ A deterministic plan containing results, conflicts, and ordered effects.
+planReconciliation direction policy inputs =
+  ReconciliationPlan
+    { direction = direction
+    , conflictPolicy = policy
+    , items = fmap (\(item, _, _) -> item) planned
+    , conflicts = concatMap (\(_, conflicts, _) -> conflicts) planned
+    , operations = normalizeOperations $ concatMap (\(_, _, ops) -> ops) planned
+    }
+ where
+  planned =
+    fmap (planInput direction policy) $
+      sortOn inputOrderKey inputs
+
+
+inputOrderKey :: ReconciliationInput -> (OsPath, OsPath, OsPath)
+inputOrderKey input =
+  ( input.correspondence.intermediate.path
+  , input.correspondence.source.path
+  , input.correspondence.destination.path
+  )
+
+
+data OperationPhase = FirstPhase | SecondPhase
+  deriving (Eq, Ord, Show)
+
+
+data TaggedOperation = TaggedOperation
+  { phase :: OperationPhase
+  , plannedOperation :: PlannedSyncOp
+  }
+  deriving (Eq, Show)
+
+
+planInput
+  :: ReconciliationDirection
+  -> ConflictPolicy
+  -> ReconciliationInput
+  -> (ReconciliationItem, [ReconciliationConflict], [TaggedOperation])
+planInput direction policy input
+  | conflict && policy == RefuseConflicts =
+      ( ReconciliationItem correspondence authoritative ConflictDetected
+      , conflictList
+      , []
+      )
+  | otherwise =
+      case planSupportedInput direction input of
+        (outcome, operations) ->
+          ( ReconciliationItem correspondence authoritative outcome
+          , conflictList
+          , operations
+          )
+ where
+  correspondence = input.correspondence
+  authoritative = case direction of
+    SourceToDestination -> correspondence.source
+    DestinationToSource -> correspondence.destination
+  conflict = isConflict input
+  conflictList =
+    [ReconciliationConflict correspondence | conflict]
+
+
+isConflict :: ReconciliationInput -> Bool
+isConflict input =
+  sourceChanged
+    && destinationChanged
+    && not bothRemoved
+    && input.sourceDestinationComparison == ReplicasDifferent
+ where
+  correspondence = input.correspondence
+  sourceChanged = correspondence.sourceDelta /= Unchanged
+  destinationChanged = correspondence.destinationDelta /= Unchanged
+  bothRemoved =
+    correspondence.sourceDelta == Removed
+      && correspondence.destinationDelta == Removed
+
+
+planSupportedInput
+  :: ReconciliationDirection
+  -> ReconciliationInput
+  -> (ReconciliationOutcome, [TaggedOperation])
+planSupportedInput direction input
+  | isSymlinkStat authoritative.stat
+      && (authoritativeDelta /= Unchanged || targetNeedsUpdate) =
+      (Skipped UnsupportedSymlink, [])
+  | authoritative.stat == Missing = planRemoval
+  | otherwise = planExisting
+ where
+  correspondence = input.correspondence
+  (authoritative, authoritativeDelta, overwritten, overwrittenReplica) =
+    case direction of
+      SourceToDestination ->
+        ( correspondence.source
+        , correspondence.sourceDelta
+        , correspondence.destination
+        , DestinationReplica
+        )
+      DestinationToSource ->
+        ( correspondence.destination
+        , correspondence.destinationDelta
+        , correspondence.source
+        , SourceReplica
+        )
+  targetNeedsUpdate =
+    input.sourceDestinationComparison == ReplicasDifferent
+  planRemoval :: (ReconciliationOutcome, [TaggedOperation])
+  planRemoval =
+    let ignored = case (direction, input.destinationRouteState) of
+          (SourceToDestination, Ignored route pattern)
+            | overwritten.stat /= Missing ->
+                Just $ IgnoredDestination route pattern
+          _ -> Nothing
+        targetOperations =
+          case ignored of
+            Just _ -> []
+            Nothing ->
+              tagOperations FirstPhase overwrittenReplica $
+                removeEntry overwritten
+        intermediateOperations =
+          tagOperations SecondPhase IntermediateReplica $
+            removeEntry correspondence.intermediate
+        operations = targetOperations ++ intermediateOperations
+        outcome = case ignored of
+          Just reason -> Skipped reason
+          Nothing
+            | null operations -> NoChange
+            | otherwise -> WillReconcile
+    in (outcome, operations)
+
+  planExisting :: (ReconciliationOutcome, [TaggedOperation])
+  planExisting =
+    let intermediateOperations =
+          if authoritativeDelta == Unchanged
+            then []
+            else
+              tagOperations FirstPhase IntermediateReplica $
+                replaceEntry authoritative correspondence.intermediate
+        stagedIntermediate =
+          FileEntry correspondence.intermediate.path authoritative.stat
+        targetOperations =
+          if not targetNeedsUpdate
+            then []
+            else
+              tagOperations SecondPhase overwrittenReplica $
+                replaceEntry stagedIntermediate overwritten
+        operations = intermediateOperations ++ targetOperations
+    in (if null operations then NoChange else WillReconcile, operations)
+
+
+isSymlinkStat :: FileStat -> Bool
+isSymlinkStat (Symlink _) = True
+isSymlinkStat _ = False
+
+
+tagOperations :: OperationPhase -> Replica -> [SyncOp] -> [TaggedOperation]
+tagOperations phase replica =
+  fmap $ TaggedOperation phase . PlannedSyncOp replica
+
+
+removeEntry :: FileEntry -> [SyncOp]
+removeEntry (FileEntry _ Missing) = []
+removeEntry (FileEntry path Directory) = [RemoveDirs path]
+removeEntry (FileEntry path _) = [RemoveFile path]
+
+
+replaceEntry :: FileEntry -> FileEntry -> [SyncOp]
+replaceEntry from to = case from.stat of
+  Missing -> removeEntry to
+  Directory -> case to.stat of
+    Missing -> [CreateDirs to.path]
+    Directory -> []
+    _ -> [RemoveFile to.path, CreateDirs to.path]
+  File _ -> replaceWithFile
+  Symlink _ -> []
+ where
+  replaceWithFile = case to.stat of
+    Missing -> createAndCopy
+    File _ -> [CopyFile from.path to.path]
+    Symlink _ -> RemoveFile to.path : createAndCopy
+    Directory -> RemoveDirs to.path : createAndCopy
+  createAndCopy =
+    [ CreateDirs $ takeDirectory to.path
+    , CopyFile from.path to.path
+    ]
+
+
+normalizeOperations :: [TaggedOperation] -> [PlannedSyncOp]
+normalizeOperations operations =
+  fmap (.plannedOperation) $
+    nub $
+      sortBy compareTaggedOperation $
+        filter (not . shadowedByRecursiveRemoval operations) operations
+
+
+shadowedByRecursiveRemoval :: [TaggedOperation] -> TaggedOperation -> Bool
+shadowedByRecursiveRemoval operations operation =
+  any shadows operations
+ where
+  candidate = operation.plannedOperation
+  candidatePath = syncOpTarget candidate.syncOp
+  shadows :: TaggedOperation -> Bool
+  shadows other =
+    other.plannedOperation.replica == candidate.replica
+      && case other.plannedOperation.syncOp of
+        RemoveDirs path -> path `strictlyContains` candidatePath
+        _ -> False
+
+
+strictlyContains :: OsPath -> OsPath -> Bool
+strictlyContains parent child =
+  let parentParts = splitDirectories $ normalise parent
+      childParts = splitDirectories $ normalise child
+  in length parentParts < length childParts
+       && parentParts `isPrefixOf` childParts
+
+
+compareTaggedOperation :: TaggedOperation -> TaggedOperation -> Ordering
+compareTaggedOperation a b = compare (operationKey a) (operationKey b)
+
+
+operationKey
+  :: TaggedOperation
+  -> (OperationPhase, Int, Int, Replica, OsPath, SyncOp)
+operationKey operation =
+  ( operation.phase
+  , category
+  , depthKey
+  , operation.plannedOperation.replica
+  , path
+  , operation.plannedOperation.syncOp
+  )
+ where
+  syncOperation = operation.plannedOperation.syncOp
+  path = syncOpTarget syncOperation
+  depth = length $ splitDirectories $ normalise path
+  (category, depthKey) = case syncOperation of
+    RemoveDirs _ -> (0, negate depth)
+    RemoveFile _ -> (0, negate depth)
+    CreateDir _ -> (1, depth)
+    CreateDirs _ -> (1, depth)
+    CopyFile _ _ -> (2, depth)
+
+
+syncOpTarget :: SyncOp -> OsPath
+syncOpTarget (RemoveDirs path) = path
+syncOpTarget (RemoveFile path) = path
+syncOpTarget (CopyFile _ destination) = destination
+syncOpTarget (CreateDir path) = path
+syncOpTarget (CreateDirs path) = path
+
+
+-- | Whether an operation removes an existing filesystem entry.
+isDestructiveSyncOp
+  :: SyncOp
+  -- ^ The operation to classify.
+  -> Bool
+  -- ^ Whether it removes a file or directory.
+isDestructiveSyncOp (RemoveDirs _) = True
+isDestructiveSyncOp (RemoveFile _) = True
+isDestructiveSyncOp _ = False
+
+
+-- | Returns the destructive subset of a plan without changing its order.
+destructiveOperations
+  :: ReconciliationPlan
+  -- ^ The plan to inspect.
+  -> [PlannedSyncOp]
+  -- ^ The destructive operations in their original execution order.
+destructiveOperations plan =
+  filter (isDestructiveSyncOp . (.syncOp)) plan.operations
+
+
+-- | Interprets one synchronization operation through 'MonadFileSystem'.
+executeSyncOp
+  :: (MonadFileSystem m)
+  => SyncOp
+  -- ^ The operation to execute.
+  -> m ()
+  -- ^ The interpreted filesystem effect.
+executeSyncOp (RemoveDirs path) = removeDirectoryRecursively path
+executeSyncOp (RemoveFile path) = removeFile path
+executeSyncOp (CopyFile source destination) = copyFile source destination
+executeSyncOp (CreateDir path) = createDirectory path
+executeSyncOp (CreateDirs path) = createDirectories path
+
+
+-- | Executes a plan in order.  A refused conflict returns before the first
+-- filesystem mutation.
+executeReconciliationPlan
+  :: (MonadFileSystem m)
+  => ReconciliationPlan
+  -- ^ The plan to execute.
+  -> m (Either (NonEmpty ReconciliationConflict) ())
+  -- ^ Refused conflicts, or success after all ordered operations complete.
+executeReconciliationPlan plan =
+  case (plan.conflictPolicy, NE.nonEmpty plan.conflicts) of
+    (RefuseConflicts, Just conflicts) -> return $ Left conflicts
+    _ -> do
+      forM_ plan.operations $ executeSyncOp . (.syncOp)
+      return $ Right ()

--- a/test/Dojang/Types/ReconciliationSpec.hs
+++ b/test/Dojang/Types/ReconciliationSpec.hs
@@ -451,6 +451,23 @@ spec = do
       fmap (.outcome) plan.items
         `shouldBe` [Skipped $ IgnoredDestination route "ignored"]
 
+    it "does not reflect an ignored destination" $ do
+      let input =
+            makeInput
+              paths
+              Missing
+              Missing
+              (File 3)
+              Unchanged
+              Added
+              ReplicasDifferent
+              (Ignored route "ignored")
+      let plan =
+            planReconciliation DestinationToSource RefuseConflicts [input]
+      plan.operations `shouldBe` []
+      fmap (.outcome) plan.items
+        `shouldBe` [Skipped $ IgnoredDestination route "ignored"]
+
     it "collapses descendant work under a recursive replacement" $ do
       tree <- encodeFS "tree"
       child <- encodeFS "child"

--- a/test/Dojang/Types/ReconciliationSpec.hs
+++ b/test/Dojang/Types/ReconciliationSpec.hs
@@ -1,0 +1,701 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Dojang.Types.ReconciliationSpec (spec) where
+
+import System.OsPath (OsPath, encodeFS, takeDirectory, (</>))
+import Test.Hspec (Spec, describe, it, runIO)
+import Test.Hspec.Expectations.Pretty (shouldBe)
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range (linear)
+import Test.Hspec.Expectations.Pretty (shouldReturn, shouldSatisfy)
+import Test.Hspec.Hedgehog (MonadGen, forAll, hedgehog, (===))
+
+import Dojang.MonadFileSystem qualified as FileSystem
+import Dojang.TestUtils (withTempDir)
+import Dojang.Types.Context
+  ( Context (..)
+  , FileCorrespondence (..)
+  , FileDeltaKind (..)
+  , FileEntry (..)
+  , FileStat (..)
+  , RouteState (..)
+  )
+import Dojang.Types.Environment.Current (MonadEnvironment (currentEnvironment))
+import Dojang.Types.Manifest qualified as Manifest
+import Dojang.Types.Reconciliation
+  ( ConflictPolicy (..)
+  , PlannedSyncOp (..)
+  , ReconciliationDirection (..)
+  , ReconciliationInput (..)
+  , ReconciliationItem (..)
+  , ReconciliationOutcome (..)
+  , ReconciliationPlan (..)
+  , ReconciliationSkipReason (..)
+  , Replica (..)
+  , ReplicaComparison (..)
+  , SyncOp (..)
+  , destructiveOperations
+  , executeReconciliationPlan
+  , executeSyncOp
+  , observeReconciliationInput
+  , planReconciliation
+  )
+import Dojang.Types.Repository (Repository (..))
+
+
+data Paths = Paths
+  { source :: OsPath
+  , intermediate :: OsPath
+  , destination :: OsPath
+  }
+  deriving (Eq, Show)
+
+
+data ModelState
+  = ModelMissing
+  | ModelDirectory
+  | ModelFile Int
+  deriving (Eq, Show)
+
+
+modelState :: (MonadGen m) => m ModelState
+modelState =
+  Gen.choice
+    [ return ModelMissing
+    , return ModelDirectory
+    , ModelFile <$> Gen.int (linear 0 8)
+    ]
+
+
+modelStat :: ModelState -> FileStat
+modelStat ModelMissing = Missing
+modelStat ModelDirectory = Directory
+modelStat (ModelFile _) = File 1
+
+
+modelDelta :: ModelState -> ModelState -> FileDeltaKind
+modelDelta ModelMissing ModelMissing = Unchanged
+modelDelta ModelMissing _ = Added
+modelDelta _ ModelMissing = Removed
+modelDelta ModelDirectory ModelDirectory = Unchanged
+modelDelta (ModelFile a) (ModelFile b)
+  | a == b = Unchanged
+  | otherwise = Modified
+modelDelta _ _ = Modified
+
+
+modelComparison :: ModelState -> ModelState -> ReplicaComparison
+modelComparison a b
+  | a == b = ReplicasEquivalent
+  | otherwise = ReplicasDifferent
+
+
+makeModelInput
+  :: Paths
+  -> RouteState
+  -> ModelState
+  -> ModelState
+  -> ModelState
+  -> ReconciliationInput
+makeModelInput paths routeState sourceState intermediateState destinationState =
+  makeInput
+    paths
+    (modelStat sourceState)
+    (modelStat intermediateState)
+    (modelStat destinationState)
+    (modelDelta intermediateState sourceState)
+    (modelDelta intermediateState destinationState)
+    (modelComparison sourceState destinationState)
+    routeState
+
+
+applyModelOperations
+  :: Map OsPath ModelState
+  -> [PlannedSyncOp]
+  -> Map OsPath ModelState
+applyModelOperations = foldl' applyOperation
+ where
+  applyOperation state (PlannedSyncOp _ operation) = case operation of
+    RemoveDirs path -> Map.insert path ModelMissing state
+    RemoveFile path -> Map.insert path ModelMissing state
+    CopyFile sourcePath destinationPath ->
+      Map.insert destinationPath (state Map.! sourcePath) state
+    CreateDir path -> Map.insert path ModelDirectory state
+    CreateDirs path -> Map.insert path ModelDirectory state
+
+
+swapReplica :: Replica -> Replica
+swapReplica SourceReplica = DestinationReplica
+swapReplica IntermediateReplica = IntermediateReplica
+swapReplica DestinationReplica = SourceReplica
+
+
+swapPlannedReplica :: PlannedSyncOp -> PlannedSyncOp
+swapPlannedReplica (PlannedSyncOp replica operation) =
+  PlannedSyncOp (swapReplica replica) operation
+
+
+swapInput :: ReconciliationInput -> ReconciliationInput
+swapInput input =
+  ReconciliationInput
+    { correspondence =
+        FileCorrespondence
+          { source = input.correspondence.destination
+          , sourceDelta = input.correspondence.destinationDelta
+          , intermediate = input.correspondence.intermediate
+          , destination = input.correspondence.source
+          , destinationDelta = input.correspondence.sourceDelta
+          }
+    , sourceDestinationComparison = input.sourceDestinationComparison
+    , destinationRouteState = input.destinationRouteState
+    }
+
+
+makeInput
+  :: Paths
+  -> FileStat
+  -> FileStat
+  -> FileStat
+  -> FileDeltaKind
+  -> FileDeltaKind
+  -> ReplicaComparison
+  -> RouteState
+  -> ReconciliationInput
+makeInput paths sourceStat intermediateStat destinationStat sourceDelta destinationDelta comparison routeState =
+  ReconciliationInput
+    { correspondence =
+        FileCorrespondence
+          { source = FileEntry paths.source sourceStat
+          , sourceDelta = sourceDelta
+          , intermediate = FileEntry paths.intermediate intermediateStat
+          , destination = FileEntry paths.destination destinationStat
+          , destinationDelta = destinationDelta
+          }
+    , sourceDestinationComparison = comparison
+    , destinationRouteState = routeState
+    }
+
+
+spec :: Spec
+spec = do
+  sourceRoot <- runIO $ encodeFS "source"
+  intermediateRoot <- runIO $ encodeFS "intermediate"
+  destinationRoot <- runIO $ encodeFS "destination"
+  file <- runIO $ encodeFS "file"
+  otherFile <- runIO $ encodeFS "other-file"
+  route <- runIO $ encodeFS "route"
+  target <- runIO $ encodeFS "target"
+  let paths =
+        Paths
+          { source = sourceRoot </> file
+          , intermediate = intermediateRoot </> file
+          , destination = destinationRoot </> file
+          }
+  let routed = Routed route
+
+  describe "planReconciliation" $ do
+    it "produces no operations for an already reconciled entry" $ do
+      let input =
+            makeInput
+              paths
+              (File 3)
+              (File 3)
+              (File 3)
+              Unchanged
+              Unchanged
+              ReplicasEquivalent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations `shouldBe` []
+      plan.conflicts `shouldBe` []
+      fmap (.outcome) plan.items `shouldBe` [NoChange]
+      fmap (.desiredEntry) plan.items
+        `shouldBe` [input.correspondence.source]
+
+    it "plans a source-only addition through the intermediate replica" $ do
+      let input =
+            makeInput
+              paths
+              (File 3)
+              Missing
+              Missing
+              Added
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (CreateDirs $ takeDirectory paths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CopyFile paths.source paths.intermediate)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CreateDirs $ takeDirectory paths.destination)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CopyFile paths.intermediate paths.destination)
+                   ]
+      fmap (.outcome) plan.items `shouldBe` [WillReconcile]
+
+    it "reports an incompatible two-sided change without planning it" $ do
+      let input =
+            makeInput
+              paths
+              (File 3)
+              (File 3)
+              (File 3)
+              Modified
+              Modified
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations `shouldBe` []
+      length plan.conflicts `shouldBe` 1
+      fmap (.outcome) plan.items `shouldBe` [ConflictDetected]
+
+      let forced =
+            planReconciliation SourceToDestination PreferAuthoritative [input]
+      length forced.conflicts `shouldBe` 1
+      fmap (.outcome) forced.items `shouldBe` [WillReconcile]
+
+    it "accepts equal independent additions and only records the base" $ do
+      let input =
+            makeInput
+              paths
+              (File 3)
+              Missing
+              (File 3)
+              Added
+              Added
+              ReplicasEquivalent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (CreateDirs $ takeDirectory paths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CopyFile paths.source paths.intermediate)
+                   ]
+      plan.conflicts `shouldBe` []
+
+    it "accepts simultaneous removals and removes only the base" $ do
+      let input =
+            makeInput
+              paths
+              Missing
+              (File 3)
+              Missing
+              Removed
+              Removed
+              ReplicasEquivalent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (RemoveFile paths.intermediate)
+                   ]
+      plan.conflicts `shouldBe` []
+
+    it "replaces regular files with directories" $ do
+      let input =
+            makeInput
+              paths
+              Directory
+              (File 3)
+              (File 3)
+              Modified
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (RemoveFile paths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CreateDirs paths.intermediate)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (RemoveFile paths.destination)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CreateDirs paths.destination)
+                   ]
+
+    it "removes symbolic links before replacing them with regular files" $ do
+      let input =
+            makeInput
+              paths
+              (File 3)
+              (Symlink target)
+              (Symlink target)
+              Modified
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (RemoveFile paths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CreateDirs $ takeDirectory paths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CopyFile paths.source paths.intermediate)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (RemoveFile paths.destination)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CreateDirs $ takeDirectory paths.destination)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CopyFile paths.intermediate paths.destination)
+                   ]
+
+    it "removes the overwritten replica before the recovery copy" $ do
+      let input =
+            makeInput
+              paths
+              Missing
+              (File 3)
+              (File 3)
+              Removed
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp DestinationReplica (RemoveFile paths.destination)
+                   , PlannedSyncOp IntermediateReplica (RemoveFile paths.intermediate)
+                   ]
+      destructiveOperations plan `shouldBe` plan.operations
+
+    it "skips a symbolic link that would have to be created" $ do
+      let input =
+            makeInput
+              paths
+              (Symlink target)
+              Missing
+              Missing
+              Added
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations `shouldBe` []
+      fmap (.outcome) plan.items
+        `shouldBe` [Skipped UnsupportedSymlink]
+
+    it "preserves an ignored destination-only addition" $ do
+      let input =
+            makeInput
+              paths
+              Missing
+              Missing
+              (File 3)
+              Unchanged
+              Added
+              ReplicasDifferent
+              (Ignored route "ignored")
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations `shouldBe` []
+      fmap (.outcome) plan.items
+        `shouldBe` [Skipped $ IgnoredDestination route "ignored"]
+
+    it "collapses descendant work under a recursive replacement" $ do
+      tree <- encodeFS "tree"
+      child <- encodeFS "child"
+      let parentPaths =
+            Paths
+              { source = sourceRoot </> tree
+              , intermediate = intermediateRoot </> tree
+              , destination = destinationRoot </> tree
+              }
+      let childPaths =
+            Paths
+              { source = parentPaths.source </> child
+              , intermediate = parentPaths.intermediate </> child
+              , destination = parentPaths.destination </> child
+              }
+      let parentInput =
+            makeInput
+              parentPaths
+              (File 3)
+              Directory
+              Directory
+              Modified
+              Unchanged
+              ReplicasDifferent
+              routed
+      let childInput =
+            makeInput
+              childPaths
+              Missing
+              (File 3)
+              (File 3)
+              Removed
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation
+              SourceToDestination
+              RefuseConflicts
+              [childInput, parentInput]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (RemoveDirs parentPaths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CreateDirs $ takeDirectory parentPaths.intermediate)
+                   , PlannedSyncOp
+                       IntermediateReplica
+                       (CopyFile parentPaths.source parentPaths.intermediate)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (RemoveDirs parentPaths.destination)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CreateDirs $ takeDirectory parentPaths.destination)
+                   , PlannedSyncOp
+                       DestinationReplica
+                       (CopyFile parentPaths.intermediate parentPaths.destination)
+                   ]
+
+    it "is deterministic regardless of input order" $ hedgehog $ do
+      sourceA <- forAll modelState
+      intermediateA <- forAll modelState
+      destinationA <- forAll modelState
+      sourceB <- forAll modelState
+      intermediateB <- forAll modelState
+      destinationB <- forAll modelState
+      let paths' =
+            Paths
+              { source = sourceRoot </> otherFile
+              , intermediate = intermediateRoot </> otherFile
+              , destination = destinationRoot </> otherFile
+              }
+      let inputs =
+            [ makeModelInput paths routed sourceA intermediateA destinationA
+            , makeModelInput paths' routed sourceB intermediateB destinationB
+            ]
+      planReconciliation SourceToDestination PreferAuthoritative inputs
+        === planReconciliation
+          SourceToDestination
+          PreferAuthoritative
+          (reverse inputs)
+
+    it "is symmetric when replicas and direction are swapped" $ hedgehog $ do
+      sourceState <- forAll modelState
+      intermediateState <- forAll modelState
+      destinationState <- forAll modelState
+      policy <- forAll $ Gen.element [RefuseConflicts, PreferAuthoritative]
+      let input =
+            makeModelInput
+              paths
+              routed
+              sourceState
+              intermediateState
+              destinationState
+      let forward =
+            planReconciliation SourceToDestination policy [input]
+      let backward =
+            planReconciliation DestinationToSource policy [swapInput input]
+      fmap swapPlannedReplica forward.operations === backward.operations
+      fmap (.outcome) forward.items === fmap (.outcome) backward.items
+      length forward.conflicts === length backward.conflicts
+
+    it "converges supported states and is then idempotent" $ hedgehog $ do
+      sourceState <- forAll modelState
+      intermediateState <- forAll modelState
+      destinationState <- forAll modelState
+      direction <-
+        forAll $ Gen.element [SourceToDestination, DestinationToSource]
+      let input =
+            makeModelInput
+              paths
+              routed
+              sourceState
+              intermediateState
+              destinationState
+      let plan = planReconciliation direction PreferAuthoritative [input]
+      let initial =
+            Map.fromList
+              [ (paths.source, sourceState)
+              , (paths.intermediate, intermediateState)
+              , (paths.destination, destinationState)
+              ]
+      let final = applyModelOperations initial plan.operations
+      let authoritative = case direction of
+            SourceToDestination -> sourceState
+            DestinationToSource -> destinationState
+      final Map.! paths.source === authoritative
+      final Map.! paths.intermediate === authoritative
+      final Map.! paths.destination === authoritative
+      let reconciled =
+            makeModelInput paths routed authoritative authoritative authoritative
+      let secondPlan =
+            planReconciliation direction RefuseConflicts [reconciled]
+      secondPlan.operations === []
+      fmap (.outcome) secondPlan.items === [NoChange]
+
+  describe "observeReconciliationInput" $ do
+    it "compares equal-size files by content" $ withTempDir $ \tmpDir _ -> do
+      sourceName <- encodeFS "source-file"
+      destinationName <- encodeFS "destination-file"
+      intermediateName <- encodeFS "intermediate-file"
+      intermediateDir <- encodeFS ".dojang"
+      let sourcePath = tmpDir </> sourceName
+      let destinationPath = tmpDir </> destinationName
+      FileSystem.writeFile sourcePath "same"
+      FileSystem.writeFile destinationPath "same"
+      environment <- currentEnvironment
+      let repository =
+            Repository
+              tmpDir
+              (tmpDir </> intermediateDir)
+              (Manifest.manifest mempty mempty mempty mempty mempty)
+      let context = Context repository environment (const $ return Nothing)
+      let correspondence =
+            FileCorrespondence
+              { source = FileEntry sourcePath (File 4)
+              , sourceDelta = Modified
+              , intermediate = FileEntry (tmpDir </> intermediateName) (File 4)
+              , destination = FileEntry destinationPath (File 4)
+              , destinationDelta = Modified
+              }
+      equalInput <- observeReconciliationInput context correspondence
+      equalInput.sourceDestinationComparison `shouldBe` ReplicasEquivalent
+      equalInput.destinationRouteState `shouldBe` NotRouted
+
+      FileSystem.writeFile destinationPath "else"
+      differentInput <- observeReconciliationInput context correspondence
+      differentInput.sourceDestinationComparison `shouldBe` ReplicasDifferent
+
+  describe "execution" $ do
+    it "interprets every synchronization operation" $ withTempDir $ \tmpDir _ -> do
+      sourceName <- encodeFS "source-file"
+      parentName <- encodeFS "parent"
+      nestedName <- encodeFS "nested"
+      copiedName <- encodeFS "copied"
+      emptyName <- encodeFS "empty"
+      let sourcePath = tmpDir </> sourceName
+      let nestedPath = tmpDir </> parentName </> nestedName
+      let copiedPath = nestedPath </> copiedName
+      let emptyPath = nestedPath </> emptyName
+      FileSystem.writeFile sourcePath "contents"
+      executeSyncOp $ CreateDirs nestedPath
+      executeSyncOp $ CopyFile sourcePath copiedPath
+      FileSystem.readFile copiedPath `shouldReturn` "contents"
+      executeSyncOp $ RemoveFile copiedPath
+      FileSystem.exists copiedPath `shouldReturn` False
+      executeSyncOp $ CreateDir emptyPath
+      FileSystem.isDirectory emptyPath `shouldReturn` True
+      executeSyncOp $ RemoveDirs nestedPath
+      FileSystem.exists nestedPath `shouldReturn` False
+
+    it "executes a ready plan to convergence" $ withTempDir $ \tmpDir _ -> do
+      sourceName <- encodeFS "source-file"
+      intermediateName <- encodeFS "intermediate-file"
+      destinationName <- encodeFS "destination-file"
+      let executionPaths =
+            Paths
+              { source = tmpDir </> sourceName
+              , intermediate = tmpDir </> intermediateName
+              , destination = tmpDir </> destinationName
+              }
+      FileSystem.writeFile executionPaths.source "contents"
+      let input =
+            makeInput
+              executionPaths
+              (File 8)
+              Missing
+              Missing
+              Added
+              Unchanged
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      executeReconciliationPlan plan `shouldReturn` Right ()
+      FileSystem.readFile executionPaths.intermediate `shouldReturn` "contents"
+      FileSystem.readFile executionPaths.destination `shouldReturn` "contents"
+
+    it "refuses the whole plan before any mutation" $ withTempDir $ \tmpDir _ -> do
+      sourceName <- encodeFS "source-file"
+      intermediateName <- encodeFS "intermediate-file"
+      destinationName <- encodeFS "destination-file"
+      conflictName <- encodeFS "conflict"
+      let additionPaths =
+            Paths
+              { source = tmpDir </> sourceName
+              , intermediate = tmpDir </> intermediateName
+              , destination = tmpDir </> destinationName
+              }
+      let conflictPaths =
+            Paths
+              { source = tmpDir </> conflictName
+              , intermediate = tmpDir </> conflictName
+              , destination = tmpDir </> conflictName
+              }
+      FileSystem.writeFile additionPaths.source "contents"
+      let addition =
+            makeInput
+              additionPaths
+              (File 8)
+              Missing
+              Missing
+              Added
+              Unchanged
+              ReplicasDifferent
+              routed
+      let conflict =
+            makeInput
+              conflictPaths
+              (File 3)
+              (File 3)
+              (File 3)
+              Modified
+              Modified
+              ReplicasDifferent
+              routed
+      let plan =
+            planReconciliation
+              SourceToDestination
+              RefuseConflicts
+              [addition, conflict]
+      result <- executeReconciliationPlan plan
+      result `shouldSatisfy` \case
+        Left _ -> True
+        Right _ -> False
+      FileSystem.exists additionPaths.intermediate `shouldReturn` False
+      FileSystem.exists additionPaths.destination `shouldReturn` False

--- a/test/Dojang/Types/ReconciliationSpec.hs
+++ b/test/Dojang/Types/ReconciliationSpec.hs
@@ -430,6 +430,27 @@ spec = do
       fmap (.outcome) plan.items
         `shouldBe` [Skipped $ IgnoredDestination route "ignored"]
 
+    it "updates the intermediate while preserving an ignored destination" $ do
+      let input =
+            makeInput
+              paths
+              (File 3)
+              (File 4)
+              (File 4)
+              Modified
+              Unchanged
+              ReplicasDifferent
+              (Ignored route "ignored")
+      let plan =
+            planReconciliation SourceToDestination RefuseConflicts [input]
+      plan.operations
+        `shouldBe` [ PlannedSyncOp
+                       IntermediateReplica
+                       (CopyFile paths.source paths.intermediate)
+                   ]
+      fmap (.outcome) plan.items
+        `shouldBe` [Skipped $ IgnoredDestination route "ignored"]
+
     it "collapses descendant work under a recursive replacement" $ do
       tree <- encodeFS "tree"
       child <- encodeFS "child"


### PR DESCRIPTION
Closes #29 as the planning layer of #28.

Dojang already observes synchronization through three replicas, but the apply path could only discover its full effect by executing part of the work in `DryRunIO` and scanning the simulated filesystem again.  That made deletion guards and conflict handling properties of a command pipeline instead of values that callers could inspect before mutation.

This PR draws a strict boundary between observation, planning, and execution. The effectful boundary turns a `FileCorrespondence` and route state into a `ReconciliationInput`.  From there, the planner is pure: it takes a direction and conflict policy, chooses the authoritative replica, and returns desired end states together with conflicts, skipped entries, destructive operations, and a stable operation sequence.  A small `MonadFileSystem` interpreter executes that sequence without taking on command-layer concerns such as prompts, hooks, logging, or exit codes.

The plan models source/intermediate/destination convergence directly rather than simulating its first leg.  Incompatible changes on both outer replicas are reported as conflicts, while equal independent additions and simultaneous removals converge without one.  Refusing conflicts blocks the whole plan before the executor mutates anything.  A forced policy keeps the same analysis but selects the authoritative side explicitly.

Operation order carries the recovery guarantees that were previously implicit in command code.  Parent directories are created before their children, recursive removals absorb redundant descendant work, and incompatible entry kinds are removed before replacement.  Deletions remove the replica being overwritten before discarding the intermediate copy, so a failed first step does not destroy the remaining recovery state.

`SyncOp` and its interpreter now live in *src/Dojang/Types/Reconciliation.hs*.  *src/Dojang/Commands/Apply.hs* calls the shared interpreter, but still uses its existing planner and command behavior. Keeping migration out of this PR makes the planning policy reviewable on its own and leaves the apply/reflect transition to the next sub-issue.

The tests use table-driven examples for boundary cases and Hedgehog properties for the rules that should hold across arbitrary states.  They check directional symmetry, determinism under reordered inputs, convergence after execution, and idempotence on a second plan.  Focused examples cover conflicts, equal additions, simultaneous removals, file/directory replacement, symbolic links, ignored destinations, destructive-operation classification, and recovery-safe ordering.  Executor tests also verify that a refused plan performs no partial mutation.